### PR TITLE
演習3-1②（外国語レッスンのマッチングサービス２週目）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 gem 'devise-i18n'
 gem 'haml-rails'
+gem 'kaminari'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'sgcop', github: 'SonicGarden/sgcop'
+  gem 'letter_opener_web'
+  gem 'rexml'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -27,18 +27,18 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'
 gem 'haml-rails'
 gem 'kaminari'
-gem 'carrierwave'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'sgcop', github: 'SonicGarden/sgcop'
   gem 'letter_opener_web'
   gem 'rexml'
+  gem 'sgcop', github: 'SonicGarden/sgcop'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'devise'
 gem 'devise-i18n'
 gem 'haml-rails'
 gem 'kaminari'
+gem 'carrierwave'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -291,6 +303,7 @@ DEPENDENCIES
   devise-i18n
   haml-rails
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,14 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.4.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -320,11 +328,13 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.7)
   kaminari
+  letter_opener_web
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
+  rexml
   sass-rails (>= 6)
   selenium-webdriver
   sgcop!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (2.2.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     childprocess (3.0.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -127,6 +135,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     kaminari (1.2.1)
@@ -151,6 +162,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.0)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -233,6 +245,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.2)
+      ffi (~> 1.12)
     ruby_parser (3.17.0)
       sexp_processor (~> 4.15, >= 4.15.1)
     rubyzip (2.3.2)
@@ -259,6 +273,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.0.7)
     sysexits (1.2.0)
     temple (0.8.2)
     thor (1.1.0)
@@ -299,6 +314,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  carrierwave
   devise
   devise-i18n
   haml-rails

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -18,6 +18,12 @@ class Admins::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def login_as_teachers
+    @teacher = Teacher.find(params[:id])
+    sign_in @teacher
+    redirect_to teachers_path, notice: "#{@teacher.name}先生としてログインしました"
+  end
+
   protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,5 +1,5 @@
 class AdminsController < ApplicationController
   def show
-    @teachers = Teacher.all
+    @teachers = Teacher.all.page(params[:page])
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,4 +1,6 @@
 class AdminsController < ApplicationController
+  before_action :authenticate_admin!
+  
   def show
     @teachers = Teacher.all.page(params[:page])
   end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,6 +1,6 @@
 class AdminsController < ApplicationController
   before_action :authenticate_admin!
-  
+
   def show
     @teachers = Teacher.all.page(params[:page])
   end

--- a/app/controllers/lesson_reservations_controller.rb
+++ b/app/controllers/lesson_reservations_controller.rb
@@ -5,6 +5,8 @@ class LessonReservationsController < ApplicationController
       redirect_to home_students_path, notice: 'チケットを購入してください'
     else
       lesson_reservation.save!
+      NoticeMailer.reservation_notice_to_student(lesson_reservation.lesson).deliver_now
+      NoticeMailer.reservation_notice_to_teacher(lesson_reservation.lesson).deliver_now
       redirect_to home_students_path, notice: 'レッスンを予約しました'
     end
   end

--- a/app/controllers/lesson_reservations_controller.rb
+++ b/app/controllers/lesson_reservations_controller.rb
@@ -1,8 +1,12 @@
 class LessonReservationsController < ApplicationController
   def create
     lesson_reservation = current_student.lesson_reservations.new(lesson_id: params[:lesson_reservation][:lesson_id])
-    lesson_reservation.save!
-    redirect_to home_students_path, notice: 'レッスンを予約しました'
+    if current_student.rest_of_lesson_count <= 0
+      redirect_to home_students_path, notice: 'チケットを購入してください'
+    else
+      lesson_reservation.save!
+      redirect_to home_students_path, notice: 'レッスンを予約しました'
+    end
   end
 
   def destroy

--- a/app/controllers/lesson_reservations_controller.rb
+++ b/app/controllers/lesson_reservations_controller.rb
@@ -1,7 +1,13 @@
 class LessonReservationsController < ApplicationController
   def create
+    lesson_reservation = current_student.lesson_reservations.new(lesson_id: params[:lesson_reservation][:lesson_id])
+    lesson_reservation.save!
+    redirect_to home_students_path, notice: 'レッスンを予約しました'
   end
 
   def destroy
+    lesson_reservation = current_student.lesson_reservations.find(params[:id])
+    lesson_reservation.destroy!
+    redirect_to home_students_path, notice: 'レッスン予約を解除しました'
   end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -13,6 +13,7 @@ class LessonsController < ApplicationController
   end
 
   def show
+    @lesson = Lesson.find(params[:id])
   end
 
   def destroy

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -12,6 +12,9 @@ class LessonsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   def destroy
     @lesson = current_teacher.lessons.find(params[:id])
     @lesson.destroy!

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -8,7 +8,7 @@ class LessonsController < ApplicationController
     if @lesson.save
       redirect_to teachers_path, notice: 'レッスンを作成しました'
     else
-      rendert :new
+      render :new
     end
   end
 

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -13,6 +13,9 @@ class LessonsController < ApplicationController
   end
 
   def destroy
+    @lesson = current_teacher.lessons.find(params[:id])
+    @lesson.destroy!
+    redirect_to teachers_path, notice: '削除しました'
   end
 
   private

--- a/app/controllers/purchase_tickets_controller.rb
+++ b/app/controllers/purchase_tickets_controller.rb
@@ -1,7 +1,20 @@
 class PurchaseTicketsController < ApplicationController
   def new
+    @purchase_ticket = current_student.purchase_tickets.new
   end
 
   def create
+    @purchase_ticket = current_student.purchase_tickets.new(purchase_ticket_params)
+    if @purchase_ticket.save
+      redirect_to students_path, notice: 'チケットを買いました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def purchase_ticket_params
+    params.require(:purchase_ticket).permit(:ticket_id)
   end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,6 +1,8 @@
 class StudentsController < ApplicationController
+  before_action :authenticate_student!
+  
   def home
-    @lessons = Lesson.where.not(id: LessonReservation.pluck(:lesson_id)).after_today.page(params[:page])
+    @lessons = Lesson.where.not(id: LessonReservation.select(:lesson_id)).after_today.page(params[:page])
     if params[:teacher_name].present?
       @lessons = @lessons.joins(:teacher).search_by_teacher_name(params[:teacher_name]).page(params[:page])
     end
@@ -13,7 +15,7 @@ class StudentsController < ApplicationController
   end
 
   def index
-    @lessons = current_student.lessons.page(params[:page])
+    @lessons = current_student.lessons.after_today.page(params[:page])
   end
 
   def show

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,8 +1,19 @@
 class StudentsController < ApplicationController
   def home
+    @lessons = Lesson.where.not(id: LessonReservation.pluck(:lesson_id)).page(params[:page])
+    if params[:teacher].present?
+      @lessons = @lessons.joins(:teacher).where('teachers.name LIKE ?', params[:teacher]).page(params[:page])
+    end
+    if params[:language].present?
+      @lessons = @lessons.joins(teacher: :language).where('languages.id::text LIKE ?', params[:language]).page(params[:page])
+    end
+    if params[:date].present?
+      @lessons = @lessons.where('started_at >= ? AND ? >= started_at', params[:date].in_time_zone.beginning_of_day, params[:date].in_time_zone.end_of_day).page(params[:page])
+    end
   end
 
   def index
+    @lessons = current_student.lessons.page(params[:page])
   end
 
   def show

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,6 +1,6 @@
 class StudentsController < ApplicationController
   before_action :authenticate_student!
-  
+
   def home
     @lessons = Lesson.where.not(id: LessonReservation.select(:lesson_id)).after_today.page(params[:page])
     if params[:teacher_name].present?

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,14 +1,14 @@
 class StudentsController < ApplicationController
   def home
-    @lessons = Lesson.where.not(id: LessonReservation.pluck(:lesson_id)).page(params[:page])
-    if params[:teacher].present?
-      @lessons = @lessons.joins(:teacher).where('teachers.name LIKE ?', params[:teacher]).page(params[:page])
+    @lessons = Lesson.where.not(id: LessonReservation.pluck(:lesson_id)).after_today.page(params[:page])
+    if params[:teacher_name].present?
+      @lessons = @lessons.joins(:teacher).search_by_teacher_name(params[:teacher_name]).page(params[:page])
     end
-    if params[:language].present?
-      @lessons = @lessons.joins(teacher: :language).where('languages.id::text LIKE ?', params[:language]).page(params[:page])
+    if params[:language_id].present?
+      @lessons = @lessons.joins(teacher: :language).search_by_language_id(params[:language_id]).page(params[:page])
     end
     if params[:date].present?
-      @lessons = @lessons.where('started_at >= ? AND ? >= started_at', params[:date].in_time_zone.beginning_of_day, params[:date].in_time_zone.end_of_day).page(params[:page])
+      @lessons = @lessons.search_by_date(params[:date]).page(params[:page])
     end
   end
 
@@ -17,5 +17,6 @@ class StudentsController < ApplicationController
   end
 
   def show
+    @student = current_student
   end
 end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,5 +1,6 @@
 class TeachersController < ApplicationController
   def home
+    @lessons = Lesson.where.not(id: LessonReservation.pluck(:lesson_id)).page(params[:page])
   end
 
   def index

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -3,6 +3,7 @@ class TeachersController < ApplicationController
   end
 
   def index
+    @lessons = current_teacher.lessons.page(params[:page])
   end
 
   def new
@@ -19,6 +20,7 @@ class TeachersController < ApplicationController
   end
 
   def show
+    @teacher = current_teacher
   end
 
   def destroy

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,6 +1,8 @@
 class TeachersController < ApplicationController
+  before_action :authenticate_teacher!, except: %i[ new create destroy]
+  before_action :authenticate_admin!, only: %i[ new create destroy]
+
   def home
-    @lessons = Lesson.where.not(id: LessonReservation.pluck(:lesson_id)).page(params[:page])
   end
 
   def index

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,6 +1,6 @@
 class TeachersController < ApplicationController
-  before_action :authenticate_teacher!, except: %i[ new create destroy]
-  before_action :authenticate_admin!, only: %i[ new create destroy]
+  before_action :authenticate_teacher!, except: %i[new create destroy]
+  before_action :authenticate_admin!, only: %i[new create destroy]
 
   def home
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def languages_option
+    Language.all.map{ |language| [language.name, language.id] }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def languages_option
-    Language.all.map{ |language| [language.name, language.id] }
+    Language.all.map { |language| [language.name, language.id] }
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'example@example.com'
   layout 'mailer'
 end

--- a/app/mailers/notice_mailer.rb
+++ b/app/mailers/notice_mailer.rb
@@ -1,0 +1,11 @@
+class NoticeMailer < ApplicationMailer
+  def reservation_notice_to_student(lesson)
+    @lesson = lesson
+    mail to: 'example@example.com', subject: '予約確認メール'
+    #本来lesson.lesson_reservation.student.email等で送信先は指定すべきですが、今回はlocalのみのため適当なアドレスを指定しました
+  end
+  def reservation_notice_to_teacher(lesson)
+    @lesson = lesson
+    mail to: 'example@example.com', subject: '予約受付メール'  #本来lesson.teacher.email等で送信先は指定すべきですが、今回はlocalのみのため適当なアドレスを指定しました
+  end
+end

--- a/app/mailers/notice_mailer.rb
+++ b/app/mailers/notice_mailer.rb
@@ -2,10 +2,11 @@ class NoticeMailer < ApplicationMailer
   def reservation_notice_to_student(lesson)
     @lesson = lesson
     mail to: 'example@example.com', subject: '予約確認メール'
-    #本来lesson.lesson_reservation.student.email等で送信先は指定すべきですが、今回はlocalのみのため適当なアドレスを指定しました
+    # 本来lesson.lesson_reservation.student.email等で送信先は指定すべきですが、今回はlocalのみのため適当なアドレスを指定しました
   end
+
   def reservation_notice_to_teacher(lesson)
     @lesson = lesson
-    mail to: 'example@example.com', subject: '予約受付メール'  #本来lesson.teacher.email等で送信先は指定すべきですが、今回はlocalのみのため適当なアドレスを指定しました
+    mail to: 'example@example.com', subject: '予約受付メール'  # 本来lesson.teacher.email等で送信先は指定すべきですが、今回はlocalのみのため適当なアドレスを指定しました
   end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,6 +1,9 @@
 class Lesson < ApplicationRecord
   belongs_to :teacher
-  has_one :lesson_reservation
+  has_one :lesson_reservation, dependent: :destroy
+  has_one :student, through: :lesson_reservation, source: :student
+  validates :started_at, presence: true
+
   scope :after_today, -> {where('started_at >= ?', Date.today)}
   scope :search_by_teacher_name, -> (teacher_name) {where('teachers.name LIKE ?', teacher_name)}
   scope :search_by_language_id, -> (language_id) {where('languages.id::text LIKE ?', language_id)}

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -4,8 +4,8 @@ class Lesson < ApplicationRecord
   has_one :student, through: :lesson_reservation, source: :student
   validates :started_at, presence: true
 
-  scope :after_today, -> {where('started_at >= ?', Date.today)}
-  scope :search_by_teacher_name, -> (teacher_name) {where('teachers.name LIKE ?', teacher_name)}
-  scope :search_by_language_id, -> (language_id) {where('languages.id::text LIKE ?', language_id)}
-  scope :search_by_date, -> (date) {where(started_at: date.in_time_zone.all_day)}
+  scope :after_today, -> { where('started_at >= ?', Time.zone.today) }
+  scope :search_by_teacher_name, ->(teacher_name) { where('teachers.name LIKE ?', teacher_name) }
+  scope :search_by_language_id, ->(language_id) { where('languages.id::text LIKE ?', language_id) }
+  scope :search_by_date, ->(date) { where(started_at: date.in_time_zone.all_day) }
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,4 +1,8 @@
 class Lesson < ApplicationRecord
   belongs_to :teacher
   has_one :lesson_reservation
+  scope :after_today, -> {where('started_at >= ?', Date.today)}
+  scope :search_by_teacher_name, -> (teacher_name) {where('teachers.name LIKE ?', teacher_name)}
+  scope :search_by_language_id, -> (language_id) {where('languages.id::text LIKE ?', language_id)}
+  scope :search_by_date, -> (date) {where(started_at: date.in_time_zone.all_day)}
 end

--- a/app/models/lesson_reservation.rb
+++ b/app/models/lesson_reservation.rb
@@ -1,5 +1,5 @@
 class LessonReservation < ApplicationRecord
   belongs_to :student
   belongs_to :lesson
-  validates :student_id, uniqueness: {scope: :lesson_id}
+  validates :student_id, uniqueness: { scope: :lesson_id }
 end

--- a/app/models/lesson_reservation.rb
+++ b/app/models/lesson_reservation.rb
@@ -1,4 +1,5 @@
 class LessonReservation < ApplicationRecord
   belongs_to :student
   belongs_to :lesson
+  validates :student_id, uniqueness: {scope: :lesson_id}
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -7,4 +7,10 @@ class Student < ApplicationRecord
   has_many :lessons, through: :lesson_reservations, source: :lesson
   has_many :purchase_tickets, dependent: :destroy
   has_many :tickets, through: :purchase_tickets, source: :ticket
+
+  def rest_of_lesson_count
+    lesson_count = self.tickets.sum(:lesson_count)
+    used_one = self.lesson_reservations.count
+    lesson_count - used_one
+  end
 end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,6 +1,7 @@
 class Teacher < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  mount_uploader :image, ImageUploader
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
   belongs_to :language

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -3,5 +3,6 @@ class Teacher < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
+  belongs_to :language
   has_many :lessons, dependent: :destroy
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+    process resize_to_fit: [300, 300]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -3,4 +3,6 @@
   %p
     #{teacher.name}先生
     = link_to '削除', teacher_path(teacher), method: :delete
+    = link_to '代理ログイン', admin_login_as_teachers_path(id: teacher), method: :post
 = link_to '講師作成', new_teacher_path
+= paginate @teachers

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,9 @@
       = link_to '講師一覧（管理者）', admin_path
       = link_to 'ログアウト（管理者）', destroy_admin_session_path, method: :delete
     - if student_signed_in?
+      = link_to 'ホーム（生徒）', home_students_path
+      = link_to 'マイレッスン（生徒）', students_path
+      = link_to 'マイページ（生徒）', student_path(current_student)
       = link_to 'ログアウト（生徒）', destroy_student_session_path, method: :delete
     - if teacher_signed_in?
       = link_to 'マイレッスン（講師）', teachers_path

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,6 +15,7 @@
       = link_to 'ログイン（講師）', new_teacher_session_path
 
     - if admin_signed_in?
+      = link_to '講師一覧（管理者）', admin_path
       = link_to 'ログアウト（管理者）', destroy_admin_session_path, method: :delete
     - if student_signed_in?
       = link_to 'ログアウト（生徒）', destroy_student_session_path, method: :delete

--- a/app/views/lesson_reservations/_lesson_reservation_form.haml
+++ b/app/views/lesson_reservations/_lesson_reservation_form.haml
@@ -4,4 +4,4 @@
 - else
   = form_with(model: current_student.lesson_reservations.new(lesson_id: lesson.id)) do |f|
     = f.hidden_field :lesson_id
-    = f.submit
+    = f.submit '予約する'

--- a/app/views/lesson_reservations/_lesson_reservation_form.haml
+++ b/app/views/lesson_reservations/_lesson_reservation_form.haml
@@ -1,2 +1,7 @@
-%h1 LessonReservations#new
-%p Find me in app/views/lesson_reservations/index.html.haml
+- if current_student.lessons.include?(lesson)
+  - lesson_reservation = current_student.lesson_reservations.find_by(lesson_id: lesson.id)
+  = button_to '予約解除', lesson_reservation_path(lesson_reservation), method: :delete
+- else
+  = form_with(model: current_student.lesson_reservations.new(lesson_id: lesson.id)) do |f|
+    = f.hidden_field :lesson_id
+    = f.submit

--- a/app/views/lessons/new.html.haml
+++ b/app/views/lessons/new.html.haml
@@ -1,5 +1,5 @@
 %h2 レッスン作成画面
 %p レッスン開始日時を指定してください
 = form_with(model: @lesson) do |f|
-  = f.datetime_field :started_at
+  = f.datetime_field :started_at, min: Date.today
   = f.submit

--- a/app/views/lessons/show.haml
+++ b/app/views/lessons/show.haml
@@ -1,0 +1,4 @@
+%p 開始時刻: #{l @lesson.started_at}
+%p 講師: #{@lesson.teacher.name}
+%p 言語: #{@lesson.teacher.language.name}
+%p zoom: #{@lesson.zoom_url}

--- a/app/views/lessons/show.haml
+++ b/app/views/lessons/show.haml
@@ -1,4 +1,5 @@
 %p 開始時刻: #{l @lesson.started_at}
 %p 講師: #{@lesson.teacher.name}
-%p 言語: #{@lesson.teacher.language.name}
+%p 言語: #{t(@lesson.teacher.language.name)}
 %p zoom: #{@lesson.zoom_url}
+%p= "生徒名: #{@lesson.student.name}" if @lesson.student.present?

--- a/app/views/notice_mailer/reservation_notice_to_student.haml
+++ b/app/views/notice_mailer/reservation_notice_to_student.haml
@@ -1,0 +1,5 @@
+%h4 予約受付内容
+%p 開始時間: #{l @lesson.started_at}
+%p 言語: #{t(@lesson.teacher.language.name)}
+%p 講師名: #{@lesson.teacher.name}
+%p zoom: #{@lesson.zoom_url}

--- a/app/views/notice_mailer/reservation_notice_to_teacher.haml
+++ b/app/views/notice_mailer/reservation_notice_to_teacher.haml
@@ -1,0 +1,5 @@
+%h4 予約受付内容
+%p 開始時間: #{l @lesson.started_at}
+%p 言語: #{t(@lesson.teacher.language.name)}
+%p 生徒名: #{@lesson.student.name}
+%p zoom: #{@lesson.zoom_url}

--- a/app/views/purchase_tickets/new.html.haml
+++ b/app/views/purchase_tickets/new.html.haml
@@ -1,2 +1,4 @@
-%h1 PurchaseTickets#new
-%p Find me in app/views/purchase_tickets/index.html.haml
+%h2 チケット購入画面
+= form_with(model: @purchase_ticket) do |f|
+  = f.text_field :ticket_id
+  = f.submit '購入'

--- a/app/views/purchase_tickets/new.html.haml
+++ b/app/views/purchase_tickets/new.html.haml
@@ -1,4 +1,5 @@
 %h2 チケット購入画面
+- tickets_option = Ticket.all.map{ |ticket| ["#{ticket.fee}円 #{ticket.lesson_count}回分", ticket.id]}
 = form_with(model: @purchase_ticket) do |f|
-  = f.text_field :ticket_id
+  = f.select :ticket_id, tickets_option, include_blank: '選択してください'
   = f.submit '購入'

--- a/app/views/students/home.html.haml
+++ b/app/views/students/home.html.haml
@@ -1,2 +1,13 @@
-%h1 Students#home
-%p Find me in app/views/students/home.html.haml
+%h2 レッスン一覧
+
+= form_with(url: home_students_path, method: :get) do |f|
+  = f.search_field :teacher, placeholder: '--講師名--'
+  = f.search_field :language
+  = f.date_field :date
+  = f.submit '検索する'
+
+- @lessons.each do |lesson|
+  %p= l lesson.started_at
+  %p 講師: #{lesson.teacher.name} / 言語: #{lesson.teacher.language.name}
+  = render 'lesson_reservations/lesson_reservation_form', lesson: lesson
+= paginate @lessons

--- a/app/views/students/home.html.haml
+++ b/app/views/students/home.html.haml
@@ -1,8 +1,8 @@
 %h2 レッスン一覧
 
 = form_with(url: home_students_path, method: :get) do |f|
-  = f.search_field :teacher, placeholder: '--講師名--'
-  = f.search_field :language
+  = f.search_field :teacher_name, placeholder: '--講師名--'
+  = f.search_field :language_id
   = f.date_field :date
   = f.submit '検索する'
 

--- a/app/views/students/home.html.haml
+++ b/app/views/students/home.html.haml
@@ -2,12 +2,12 @@
 
 = form_with(url: home_students_path, method: :get) do |f|
   = f.search_field :teacher_name, placeholder: '--講師名--'
-  = f.search_field :language_id
+  = f.select :language_id, languages_option, include_blank: '--言語--'
   = f.date_field :date
   = f.submit '検索する'
 
 - @lessons.each do |lesson|
   %p= l lesson.started_at
-  %p 講師: #{lesson.teacher.name} / 言語: #{lesson.teacher.language.name}
+  %p 講師: #{lesson.teacher.name} / 言語: #{t(lesson.teacher.language.name)}
   = render 'lesson_reservations/lesson_reservation_form', lesson: lesson
 = paginate @lessons

--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -1,6 +1,8 @@
 %h2 予約済みレッスン一覧
 - @lessons.each do |lesson|
-  %p= l lesson.started_at
+  %p
+    = l lesson.started_at
+    = link_to '詳細', lesson_path(lesson)
   = render 'lesson_reservations/lesson_reservation_form', lesson: lesson
 = link_to 'チケット購入', new_purchase_ticket_path
 = paginate @lessons

--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -1,2 +1,6 @@
 %h2 予約済みレッスン一覧
+- @lessons.each do |lesson|
+  %p= l lesson.started_at
+  = render 'lesson_reservations/lesson_reservation_form', lesson: lesson
 = link_to 'チケット購入', new_purchase_ticket_path
+= paginate @lessons

--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -1,3 +1,2 @@
-%h1 Students#index
-%p Find me in app/views/students/index.html.haml
+%h2 予約済みレッスン一覧
 = link_to 'チケット購入', new_purchase_ticket_path

--- a/app/views/students/registrations/edit.html.haml
+++ b/app/views/students/registrations/edit.html.haml
@@ -2,9 +2,13 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
+    = f.label :name
+    %br/
+    = f.text_field :name, autofocus: true, autocomplete: "name"
+  .field
     = f.label :email
     %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    = f.email_field :email, autocomplete: "email"
   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
     %div= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email)
   .field
@@ -28,8 +32,9 @@
     = f.password_field :current_password, autocomplete: "current-password"
   .actions
     = f.submit t('.update')
-%h3= t('.cancel_my_account')
-%p
-  = t('.unhappy')
-  = button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete
+-# 後々使う可能性もあるのでコメントアウトします
+-# %h3= t('.cancel_my_account')
+-# %p
+-#   = t('.unhappy')
+-#   = button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete
 = link_to t('devise.shared.links.back'), :back

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -1,2 +1,6 @@
-%h1 Students#show
-%p Find me in app/views/students/show.html.haml
+%h2 マイページ
+%p 名前：#{@student.name}
+%p Eメール：#{@student.email}
+%p 予約可能数：#{@student.rest_of_lesson_count}
+
+= link_to '編集', edit_student_registration_path

--- a/app/views/teachers/index.html.haml
+++ b/app/views/teachers/index.html.haml
@@ -1,2 +1,7 @@
 %h2 作成したレッスン一覧
+- @lessons.each do |lesson|
+  %p 
+    #{l lesson.started_at}
+    = link_to '削除', lesson_path(lesson), method: :delete 
 = link_to 'レッスン作成', new_lesson_path if !admin_signed_in?
+= paginate @lessons

--- a/app/views/teachers/index.html.haml
+++ b/app/views/teachers/index.html.haml
@@ -2,6 +2,8 @@
 - @lessons.each do |lesson|
   %p 
     #{l lesson.started_at}
+    = link_to '詳細', lesson_path(lesson) 
     = link_to '削除', lesson_path(lesson), method: :delete 
+    = '※予約あり' if lesson.lesson_reservation.present?
 = link_to 'レッスン作成', new_lesson_path if !admin_signed_in?
 = paginate @lessons

--- a/app/views/teachers/new.html.haml
+++ b/app/views/teachers/new.html.haml
@@ -11,7 +11,7 @@
   .field
     = f.label :language_id
     %br
-    = f.text_field :language_id, autocomplete: "language_id"
+    = f.select :language_id, languages_option, include_blank: '--言語--', autocomplete: "language_id"
   .field
     = f.label :password
     %br

--- a/app/views/teachers/show.html.haml
+++ b/app/views/teachers/show.html.haml
@@ -1,7 +1,7 @@
 %h2 マイページ
 %p 名前：#{@teacher.name}
 %p Eメール：#{@teacher.email}
-%p 言語：#{@teacher.language.name}
+%p 言語：#{t(@teacher.language.name)}
 %p= "#{@teacher.profile}"
 %p= image_tag @teacher.image.url if @teacher.image.present?
 

--- a/app/views/teachers/show.html.haml
+++ b/app/views/teachers/show.html.haml
@@ -1,3 +1,8 @@
-%h1 Teachers#show
-%p Find me in app/views/teachers/show.html.haml
+%h2 マイページ
+%p 名前：#{@teacher.name}
+%p Eメール：#{@teacher.email}
+%p 言語：#{@teacher.language.name}
+%p= "#{@teacher.profile}"
+%p= "画像：#{@teacher.image}" if @teacher.image.present?
+
 = link_to '編集', edit_teacher_registration_path

--- a/app/views/teachers/show.html.haml
+++ b/app/views/teachers/show.html.haml
@@ -3,6 +3,6 @@
 %p Eメール：#{@teacher.email}
 %p 言語：#{@teacher.language.name}
 %p= "#{@teacher.profile}"
-%p= "画像：#{@teacher.image}" if @teacher.image.present?
+%p= image_tag @teacher.image.url if @teacher.image.present?
 
 = link_to '編集', edit_teacher_registration_path

--- a/app/views/tops/show.html.haml
+++ b/app/views/tops/show.html.haml
@@ -1,2 +1,1 @@
-%h1 Tops#show
-%p Find me in app/views/tops/show.html.haml
+%h1 Topページ

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module MeetUpApp2
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.time_zone = 'Asia/Tokyo'
     config.generators do |g|
       g.assets false
       g.test_framework false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -252,7 +252,7 @@ Devise.setup do |config|
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
+  config.sign_out_all_scopes = false
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 15
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -201,7 +201,7 @@ ja:
   time:
     am: 午前
     formats:
-      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      default: "%Y年%m月%d日(%a) %H時%M分"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -205,3 +205,10 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+    
+  Thai: タイ語
+  Vietnamese: ベトナム語
+  Indonesian: インドネシア語
+  Malay: マレーシア語
+  Lao: ラオス語
+  Nepali: ネパール語

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,13 @@
+ja:
+  activerecord:
+    models:
+      student: 生徒
+      teacher: 講師
+    attributes:
+      student:
+        name: 名前
+      teacher:
+        name: 名前
+        profile: プロフィール
+        language_id: 言語
+        image: 画像

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       get :home
     end
   end
-  resources :lessons, only: %i[new create destroy]
+  resources :lessons, except: %i[edit update]
   resources :lesson_reservations, only: %i[create destroy]
   resources :purchase_tickets, only: %i[new create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/inbox" if Rails.env.development?
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
   devise_scope :admin do
     post 'admins/login_as_teachers', to: 'admins/sessions#login_as_teachers', as: :admin_login_as_teachers
   end
-
   devise_for :students, controllers: { sessions: 'students/sessions', registrations: 'students/registrations' }
   devise_for :teachers, controllers: { sessions: 'teachers/sessions' }
   devise_scope :teacher do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
+  devise_scope :admin do
+    post 'admins/login_as_teachers', to: 'admins/sessions#login_as_teachers', as: :admin_login_as_teachers
+  end
+
   devise_for :students, controllers: { sessions: 'students/sessions', registrations: 'students/registrations' }
   devise_for :teachers, controllers: { sessions: 'teachers/sessions' }
   devise_scope :teacher do
@@ -19,7 +23,7 @@ Rails.application.routes.draw do
       get :home
     end
   end
-  resources :lessons, only: %i[new create]
+  resources :lessons, only: %i[new create destroy]
   resources :lesson_reservations, only: %i[create destroy]
   resources :purchase_tickets, only: %i[new create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount LetterOpenerWeb::Engine, at: "/inbox" if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: '/inbox' if Rails.env.development?
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
   devise_scope :admin do
     post 'admins/login_as_teachers', to: 'admins/sessions#login_as_teachers', as: :admin_login_as_teachers

--- a/test/mailers/previews/notice_mailer_preview.rb
+++ b/test/mailers/previews/notice_mailer_preview.rb
@@ -1,0 +1,12 @@
+# Preview all emails at http://localhost:3000/rails/mailers/notice_mailer
+class NoticeMailerPreview < ActionMailer::Preview
+  def reservation_notice_to_student
+    lesson = LessonReservation.last.lesson
+    NoticeMailer.reservation_notice_to_student(lesson)
+  end
+
+  def reservation_notice_to_teacher
+    lesson = LessonReservation.last.lesson
+    NoticeMailer.reservation_notice_to_teacher(lesson)
+  end
+end


### PR DESCRIPTION
## 3-1
## ＜サービスの概要＞
英語やスペイン語といったメジャーな言語を学ぶサービスはあるものの、ミャンマー語やベトナム語などといった、日本人が学ぶ語学の中では比較的マイナーな言語を学ぶサービスはありません。
そこで、アジア諸外国の言語を学びたい人と日本で学ぶアジア諸外国の学生たちをマッチングするサービスを立ち上げることにしました。
まずはサービスに協力してくれる学生を募り、できるだけミニマムなシステムでサービスの立ち上げを目指します。
外国語レッスンではzoom.usというオンライン会議向けのツールを利用し、遠隔でレッスンを行います。

## ＜レッスンの仕様＞
- [ ] レッスンはzoom.usを利用して行う
- [ ] レッスン毎にzoomのURLが設定できる
- [ ]  所定の時間に講師・ユーザー共に所定のURLにアクセスすることでレッスンを行う
- [ ] 1レッスン50分
- [ ] 7時〜22時の間に7時の回、8時の回・・・といったようにレッスン枠が設定される
- [ ] 多様な言語のレッスンに対応するため、レッスン毎に教える言語が設定されている

## ＜ユーザー画面＞
- [ ] ユーザー登録、ログインができること
- [ ] レッスンチケットを購入できること（1回分：2000円+税、3回分：5000円+税、5回分：7500円+税）
- [ ] 講師がレッスン枠を空けている日時を検索できること
- [ ] 学びたい言語からレッスンを検索できること
- [ ] レッスンチケット残高を利用し、講師と日時を指定してレッスンを予約できること
- [ ] レッスンを予約したら1回分のレッスン残高が消費されること
- [ ] 予約したレッスンは一覧で表示され、zoomのURLを参照できること
- [ ] レッスン予約時にユーザーと講師宛にそれぞれ通知メールが飛ぶこと
- [ ] ユーザー側には少なくとも担当講師、予約時刻、zoomのURLが記載されたメールが飛ぶこと
- [ ]  講師側には少なくとも生徒ユーザー、予約時刻、zoomのURLが記載されたメールが飛ぶこと

## ＜管理者＞
- [ ] 管理者としてログインできること（管理者ユーザーはRails Consoleから登録することとする）
- [ ] 講師の管理ができること
- [ ] 作成、参照、更新、削除ができるようにする
- [ ] 講師の画面に代理ログインできるように
- [ ] 管理者画面から各講師になりすましてログインできるようにする

## ＜講師＞

- [ ] 講師としてログインできること
- [ ] 講師は管理者が手動でシステムに追加する
- [ ] プロフィールを編集できること
- [ ] 名前、顔写真、プロフィール（自己PR）、教えられる言語
- [ ] レッスン枠を登録できること
- [ ] 7:00〜、8:00〜、9:00〜・・・といった刻みで時間を設定できること
- [ ] レッスン言語を設定できること
- [ ] ユーザーの予約済みレッスンを確認できること
- [ ] ユーザー名、日時、言語、zoom URLが表示されるように

## 注意事項
以下修正できていません

- bootstrap入れるときはwebpackerで管理
→bootstrapを現段階では導入しなかったため

- student, teacherはそれぞれapplication_controller作ってauthenticate定義しよう、layoutもそれぞれ（student,teacher）作って、各々読み込ませる？
→やり方に迷ったため
homeをstudent/teacherに含めることにより、各々のcontrollerに権限を付与すれば漏れがなくなるようにはしました
※purchase_ticketやlesson_reservationは関連を使って書くことでセキュリティーを担保したつもりです
※8/16(月)に川村さんにお時間いただいたので聞いてみます

- 日付validationつくる（過去日程でlesson作成できないように）
→ 次のプルリク（演習③課題2）で修正しました

- 文字コード?（language.nameの日本語化に関して）
→ 次のプルリク（演習③課題2）で修正しました

※teacher_homeは今回使っていませんが、次の課題で使いそうなので残しています
→つかわなかったので、次のプルリク（演習③課題2）で消しました
※不必要にインスタンス変数化している点は次のプルリク（演習③課題2）で修正しました